### PR TITLE
Fix: #25 Prevent Login button from overflowing mobile menu boundary

### DIFF
--- a/tech-hire-elpaso/src/components/Header.tsx
+++ b/tech-hire-elpaso/src/components/Header.tsx
@@ -45,7 +45,7 @@ export default function Header() {
         </div>
         {/* Mobile Menu */}
         <div
-          className={`absolute xl:hidden top-22 left-0 w-full bg-white flex flex-col items-center gap-2 font-medium text-md transform transition-transform ${
+          className={`absolute xl:hidden top-22 left-0 w-full bg-white flex flex-col items-center gap-2 font-medium text-md transform transition-transform p-5 ${
             isMenuOpen ? "opacity-100" : "opacity-0"
           }`}
           style={{ transition: "transform 0.3s ease,opacity 0.3s ease" }}


### PR DESCRIPTION
##  Fix: Mobile Menu Overflow (#25)

### Problem

The "Login" button within the mobile navigation menu was overflowing the right edge of the menu container on smaller screens. This was due to the menu `div` having no horizontal **padding**, causing the content to push right up against the container's border.

### Solution

I resolved the overflow issue by adding the Tailwind CSS class **`p-5`** to the main mobile menu `div`.

* `p-5` applies a generous, consistent padding p-5 to all four sides of the menu.
* This creates the necessary buffer space to fully contain all list items and the wider "Login" button element, ensuring the mobile menu now has clean, even spacing on the left and right sides.

### Verification

* **Tested:** Confirmed on mobile breakpoints.
* The login button is now correctly contained and does not cause overflow.